### PR TITLE
Initialize TSMaster app and fix CAN FD handling in TOSUN plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,60 @@
 # python-can-tosun-tsmasterapi
 
 TOSUN同星软件接口TSMasterApi的python-can适配驱动，已测试TC1016P
-1. 修改python-can路径下的can/interfaces/__init__.py文件, 在BACKENDS字典中添加一行:
 
-   ```
-   "tosun": ("can.interfaces.tosun", "TSMasterApiBus"),
-   ```
+## 安装
 
-2. 将tosun文件夹拷贝到can/interfaces/文件夹下
+通过 python-can 的插件机制，无需修改 python-can 源代码，`pip install` 即可使用。
+
+```bash
+# 从源码安装（开发模式）
+cd python-can-tosun-tsmasterapi
+pip install -e .
+
+# 或直接安装
+pip install .
+```
+
+安装后，`tosun` 接口将自动注册到 python-can 中，可直接通过 `interface="tosun"` 使用。
 
 ## example
 
 ```python
 import can
-can_filters = [0x111, 0x222]
-bus = can.interface.Bus(bustype='tosun', channel=0, fd=True, bitrate=500000, data_bitrate=2000000,
-                            receive_own_messages=True, can_filters=can_filters, m120=True, device_name='TC1016', device_type=3, hw_index=0)
-msg = can.Message(arbitration_id=0x111,data=[0x02, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00],is_extended_id=False, )
+
+# 方式一：直接指定 interface="tosun"
+bus = can.Bus(interface='tosun', channel=0, fd=True, bitrate=500000, data_bitrate=2000000,
+              receive_own_messages=True, can_filters=[0x111, 0x222], m120=True,
+              device_name='TC1016', device_type=3, hw_sn='', hw_index=0)
+
+msg = can.Message(arbitration_id=0x111,
+                  data=[0x02, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00],
+                  is_extended_id=False)
 bus.send(msg)
-while (rec:=bus.recv(timeout=0.1)):
+
+while (rec := bus.recv(timeout=0.1)):
     print(rec)
+
 bus.shutdown()
+```
+
+```python
+# 方式二：通过配置文件
+# 在 can.rc 或环境变量中设置:
+#   [default]
+#   interface = tosun
+#   channel = 0
+import can
+bus = can.Bus()
+```
+
+## 扫描可用设备
+
+```python
+import can
+configs = can.detect_available_configs(interfaces=["tosun"])
+for config in configs:
+    print(config)
 ```
 
 ## 历史问题

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-can-tosun-tsmasterapi"
+version = "2024.6.23.1135"
+description = "TOSUN TSMasterApi python-can interface plugin"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+dependencies = [
+    "python-can>=4.0",
+]
+
+[project.entry-points."can.interface"]
+tosun = "tosun.canlib:TSMasterApiBus"
+
+[tool.setuptools.packages.find]
+include = ["tosun*"]

--- a/tosun/canlib.py
+++ b/tosun/canlib.py
@@ -40,6 +40,21 @@ open_lib = False
 open_lib_lock = Lock()
 
 
+def _build_canfd_payload(msg: can.Message):
+    payload_length = msg.dlc
+    if payload_length < 0:
+        raise ValueError("CAN FD消息长度不能为负数")
+    if payload_length > 64:
+        raise ValueError("CAN FD消息长度不能超过64字节")
+
+    payload = bytearray(msg.data[:payload_length])
+    fd_dlc = can.util.len2dlc(payload_length)
+    frame_length = can.util.dlc2len(fd_dlc)
+    if len(payload) < frame_length:
+        payload.extend(b"\x00" * (frame_length - len(payload)))
+    return payload, fd_dlc
+
+
 def _format_ts_error(code: int) -> str:
     try:
         description = TSMasterApi.tsapp_get_error_description(code)
@@ -302,11 +317,10 @@ class TSMasterApiBus(BusABC):
             else:
                 FDmsg.FProperties = FDmsg.FProperties & (~0x04)
             FDmsg.FIdentifier = msg.arbitration_id
-            FData0 = bytearray(msg.data)
-            len_FData0 = len(FData0)
-            for i in range(len_FData0):
-                FDmsg.FData[i] = FData0[i]
-            FDmsg.FDLC = BYTE_LEN2DLC[len_FData0]
+            FData0, fd_dlc = _build_canfd_payload(msg)
+            for i, data_byte in enumerate(FData0):
+                FDmsg.FData[i] = data_byte
+            FDmsg.FDLC = fd_dlc
             FDmsg.FIdxChn = 0
             if msg.is_remote_frame:
                 FDmsg.FProperties = FDmsg.FProperties | 0x02

--- a/tosun/canlib.py
+++ b/tosun/canlib.py
@@ -37,12 +37,51 @@ BYTE_LEN2DLC = {j: i for i, j in DLC2BYTE_LEN.items()}
 APP_NAME = "ForTSMasterApi"
 
 open_lib = False
+open_lib_lock = Lock()
+
+
+def _format_ts_error(code: int) -> str:
+    try:
+        description = TSMasterApi.tsapp_get_error_description(code)
+    except Exception:
+        description = "未知错误"
+
+    if isinstance(description, bytes):
+        description = description.decode("utf8", errors="ignore")
+
+    return f"错误码={code}, 描述={description}"
+
+
+def _ensure_tsmaster_initialized():
+    global open_lib
+
+    if open_lib:
+        return
+
+    with open_lib_lock:
+        if open_lib:
+            return
+
+        ret = TSMasterApi.initialize_lib_tsmaster(APP_NAME.encode("utf8"))
+        if ret != 0:
+            raise ValueError(f"初始化TSMaster失败，{_format_ts_error(ret)}")
+
+        open_lib = True
+
+
+def _activate_current_application():
+    _ensure_tsmaster_initialized()
+    ret = TSMasterApi.tsapp_set_current_application(APP_NAME.encode("utf8"))
+    if ret != 0:
+        raise ValueError(f"设置TSMaster应用失败，{_format_ts_error(ret)}")
 
 
 def clean_tosun_lib():
+    global open_lib
     if open_lib:
         log.debug('中止TSMaster DLL调用')
         TSMasterApi.finalize_lib_tsmaster()
+        open_lib = False
 
 
 atexit.register(clean_tosun_lib)
@@ -104,12 +143,19 @@ class TSMasterApiBus(BusABC):
         self.fifo_mode = fifo_mode
         self.id_filters = None
         self.receive_own_messages = receive_own_messages
-        if TSMasterApi.tsapp_set_can_channel_count(1) != 0 or TSMasterApi.tsapp_set_lin_channel_count(0) != 0:
-            TSMasterApi.tsapp_disconnect()
-            time.sleep(5)
+        _activate_current_application()
+        can_ret = TSMasterApi.tsapp_set_can_channel_count(1)
+        lin_ret = TSMasterApi.tsapp_set_lin_channel_count(0)
+        if can_ret != 0 or lin_ret != 0:
             TSMasterApi.tsapp_del_mapping_verbose(APP_NAME.encode("utf8"), 0, 0)
-            if TSMasterApi.tsapp_set_can_channel_count(1) != 0 or TSMasterApi.tsapp_set_lin_channel_count(0) != 0:
-                raise ValueError("设置CAN通道数失败")
+            TSMasterApi.tsapp_set_can_channel_count(0)
+            TSMasterApi.tsapp_set_lin_channel_count(0)
+            can_ret = TSMasterApi.tsapp_set_can_channel_count(1)
+            lin_ret = TSMasterApi.tsapp_set_lin_channel_count(0)
+            if can_ret != 0 or lin_ret != 0:
+                can_error = "OK" if can_ret == 0 else _format_ts_error(can_ret)
+                lin_error = "OK" if lin_ret == 0 else _format_ts_error(lin_ret)
+                raise ValueError(f"设置CAN通道数失败: can={can_error}; lin={lin_error}")
         # 获取参数
         channel_count: int = self.PRODUCTS[device_name]["channel_count"]
         sub_type: int = self.PRODUCTS[device_name]["sub_type"]
@@ -228,6 +274,7 @@ class TSMasterApiBus(BusABC):
                 else:
                     log.debug("注册CAN FD事件成功")
         self.lock_shutdown = Lock()
+        self.channel_info = f"TSMaster: {device_name} ch:{channel} sn:{hw_sn}"
         super().__init__(
             channel=channel,
             can_filters=can_filters,
@@ -285,6 +332,13 @@ class TSMasterApiBus(BusABC):
                 msg_tosun.FProperties = msg_tosun.FProperties & (~0x02)
             send_can_func(msg_tosun)
 
+    def _queue_message(self, msg: can.Message):
+        if not self.receive_own_messages and not msg.is_rx:
+            return
+
+        if self._matches_filters(msg):
+            self.queue_recv.put(msg)
+
     def receive_batch_frame(self):
         size = TSMasterApi.c_int32(1000)
         if not self.fd:
@@ -308,13 +362,7 @@ class TSMasterApiBus(BusABC):
                     is_rx=(ACAN.contents.FProperties & 1) == 0,
                     is_error_frame=ACAN.contents.FProperties == 0x80,
                 )
-                if not self.receive_own_messages and not msg.is_rx:  # 接受发送的消息
-                    return
-                if self.id_filters:
-                    if msg.arbitration_id in self.id_filters:
-                        self.queue_recv.put(msg)
-                else:
-                    self.queue_recv.put(msg)
+                self._queue_message(msg)
         else:
             r = TSMasterApi.tsfifo_receive_canfd_msgs(listcanfdmsg, size, 0, 1)
             if r != 0:
@@ -337,35 +385,29 @@ class TSMasterApiBus(BusABC):
                     is_rx=(ACANFD.FProperties & 1) == 0,
                     is_error_frame=ACANFD.FProperties == 0x80,
                 )
-                if not self.receive_own_messages and not msg.is_rx:  # 接受发送的消息
-                    return
-                if self.id_filters:
-                    if msg.arbitration_id in self.id_filters:
-                        self.queue_recv.put(msg)
-                else:
-                    self.queue_recv.put(msg)
+                self._queue_message(msg)
 
     def _recv_internal(self, timeout=None):
         if self.fifo_mode:
             if self.queue_recv.qsize() > 0:
-                return self.queue_recv.get(), bool(self.id_filters)
-            start_time = time.process_time()
+                return self.queue_recv.get(), bool(self._filters)
+            start_time = time.perf_counter()
             while True:
                 with self.lock_shutdown:
                     if self._is_shutdown:
                         break
                     self.receive_batch_frame()
                 if self.queue_recv.qsize() > 0:
-                    return self.queue_recv.get(), bool(self.id_filters)
-                if time.process_time() - start_time > timeout:
+                    return self.queue_recv.get(), bool(self._filters)
+                if time.perf_counter() - start_time > timeout:
                     break
                 time.sleep(0.001)
-            return None, bool(self.id_filters)
+            return None, bool(self._filters)
         else:
             try:
-                return self.queue_recv.get(timeout=timeout), bool(self.id_filters)
+                return self.queue_recv.get(timeout=timeout), bool(self._filters)
             except Empty:
-                return None, bool(self.id_filters)
+                return None, bool(self._filters)
 
     def _apply_filters(self, filters):
         self.id_filters = filters
@@ -382,10 +424,8 @@ class TSMasterApiBus(BusABC):
     @classmethod
     def _detect_available_configs(cls):
         """获取同星USB硬件列表"""
-        global open_lib
         log.debug('初始化TSMaster DLL调用')
-        TSMasterApi.initialize_lib_tsmaster(APP_NAME.encode("utf8"))  # 初始化应用
-        open_lib = True
+        _activate_current_application()
         confs = []
         # 获取硬件列表
         ACount = TSMasterApi.c_int32(0)


### PR DESCRIPTION
This pull request introduces significant improvements to the python-can TOSUN TSMasterApi interface, focusing on plugin installation, initialization robustness, CAN FD support, and code maintainability. The changes make the interface easier to install and use, enhance error handling, improve CAN FD message handling, and refactor message filtering and queuing logic for better clarity and reliability.

**Installation and Usage Improvements:**

* Updated `README.md` to document plugin-based installation using python-can's entry point mechanism, eliminating the need to manually modify the python-can source code. Usage examples and device scanning instructions are also added.
* Added `pyproject.toml` with setuptools configuration and python-can interface entry point, enabling proper pip installation and plugin registration.

**Initialization and Error Handling:**

* Refactored TSMaster library initialization with thread-safety and robust error handling, including descriptive error messages and proper application activation. [[1]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883R40-R99) [[2]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883L107-R173) [[3]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883L385-R442)

**CAN FD Message Handling:**

* Introduced `_build_canfd_payload` utility to correctly handle CAN FD payload length and DLC conversion, ensuring compliance with CAN FD specifications. [[1]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883R40-R99) [[2]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883L258-R323)

**Message Filtering and Queuing:**

* Refactored message queuing and filtering logic into a dedicated `_queue_message` method, improving maintainability and correctness of receive and filter operations. [[1]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883R349-R355) [[2]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883L311-R379) [[3]](diffhunk://#diff-a6fa0938ed947880ae22a238dd42ee5e49c4c130a3eb514c3d092e196ca76883L340-R424)

**Minor Enhancements:**

* Added `channel_info` attribute for better device/channel identification in logs and debugging.